### PR TITLE
Adding retry count and batch size as environment variable

### DIFF
--- a/tools/lambda-promtail/main.tf
+++ b/tools/lambda-promtail/main.tf
@@ -204,6 +204,7 @@ resource "aws_lambda_function" "this" {
       BEARER_TOKEN             = var.bearer_token
       KEEP_STREAM              = var.keep_stream
       BATCH_SIZE               = var.batch_size
+      RETRY_COUNT              = var.retry_count
       EXTRA_LABELS             = var.extra_labels
       DROP_LABELS              = var.drop_labels
       OMIT_EXTRA_LABELS_PREFIX = var.omit_extra_labels_prefix ? "true" : "false"

--- a/tools/lambda-promtail/variables.tf
+++ b/tools/lambda-promtail/variables.tf
@@ -108,6 +108,12 @@ variable "lambda_vpc_subnets" {
   default     = []
 }
 
+variable "retry_count" {
+  type        = number
+  description = "Retry count passed as environment variable. It determines how many times the lambda function retries pushing logs"
+  default     = 5
+}
+
 variable "lambda_vpc_security_groups" {
   type        = list(string)
   description = "List of security group IDs associated with the Lambda function."


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding retry count and batch size as environment variable

**Which issue(s) this PR fixes**:
Fixes #INFRA-1798

**Special notes for your reviewer**:

**Checklist**
- [X] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [X] Documentation added
- [X] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
  - **Note** that Promtail is considered to be feature complete, and future development for logs collection will be in [Grafana Alloy](https://github.com/grafana/alloy). As such, `feat` PRs are unlikely to be accepted unless a case can be made for the feature actually being a bug fix to existing behavior.
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
